### PR TITLE
pom.xml: add GeoTools repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,23 @@
         <spring-boot.version>3.4.0</spring-boot.version>
     </properties>
 
+    <repositories>
+        <repository>
+        <id>osgeo</id>
+        <name>OSGeo Release Repository</name>
+        <url>https://repo.osgeo.org/repository/release/</url>
+        <snapshots><enabled>false</enabled></snapshots>
+        <releases><enabled>true</enabled></releases>
+        </repository>
+        <repository>
+        <id>osgeo-snapshot</id>
+        <name>OSGeo Snapshot Repository</name>
+        <url>https://repo.osgeo.org/repository/snapshot/</url>
+        <snapshots><enabled>true</enabled></snapshots>
+        <releases><enabled>false</enabled></releases>
+        </repository>
+    </repositories>
+
     <dependencies>
         <!-- Spring Boot Web -->
         <dependency>


### PR DESCRIPTION
GeoTools has their own Maven repository.
Add it to the pom.xml to allow building and running the project, otherwise the Jars cannot be found.

See https://docs.geotools.org/latest/userguide/tutorial/quickstart/maven.html