### PR TITLE
Dockerfile: add initial Dockerized version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM openjdk:17-jdk-alpine
+COPY target/capakeylodapi-0.0.1-SNAPSHOT.jar capakeylodapi-0.0.1-SNAPSHOT.jar
+ENTRYPOINT ["java","-jar","/capakeylodapi-0.0.1-SNAPSHOT.jar"]


### PR DESCRIPTION
Deployment is much easier if the application is Dockerized, add a Dockerfile for this based on Alpine OpenJDK 17.